### PR TITLE
Enable setup-dune workflow (experimental)

### DIFF
--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -21,6 +21,6 @@ jobs:
 
       - name: Setup dune
         id: setup-dune
-        uses: mbarbin/setup-dune@8f296a5275662b3a65f6be22d8d42030f0a82441 # https://github.com/ocaml-dune/setup-dune/pull/9
+        uses: mbarbin/setup-dune@aca57022a621c5a0153a4181544827c03fd17578
         with:
           automagic: true

--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -21,6 +21,6 @@ jobs:
 
       - name: Setup dune
         id: setup-dune
-        uses: mbarbin/setup-dune@e85e050b9cb7c4df837686a4fa5569c90568fb3c # https://github.com/ocaml-dune/setup-dune/pull/9
+        uses: mbarbin/setup-dune@8f296a5275662b3a65f6be22d8d42030f0a82441 # https://github.com/ocaml-dune/setup-dune/pull/9
         with:
           automagic: true

--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -1,0 +1,26 @@
+name: Build and test with setup-dune
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**" # This will match pull requests targeting any branch
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup dune
+        id: setup-dune
+        uses: mbarbin/setup-dune@e85e050b9cb7c4df837686a4fa5569c90568fb3c # https://github.com/ocaml-dune/setup-dune/pull/9
+        with:
+          automagic: true


### PR DESCRIPTION
Try `setup-dune` with `automagic` enabled.

Currently this tracks the tip of https://github.com/ocaml-dune/setup-dune/pull/9 as a test.